### PR TITLE
ignore/types: make 'gradle' it's own type

### DIFF
--- a/ignore/src/types.rs
+++ b/ignore/src/types.rs
@@ -152,6 +152,7 @@ const DEFAULT_TYPES: &'static [(&'static str, &'static [&'static str])] = &[
     ("go", &["*.go"]),
     ("gzip", &["*.gz", "*.tgz"]),
     ("groovy", &["*.groovy", "*.gradle"]),
+    ("gradle", &["*.gradle"]),
     ("h", &["*.h", "*.hpp"]),
     ("hbs", &["*.hbs"]),
     ("haskell", &["*.hs", "*.lhs", "*.cpphs", "*.c2hs", "*.hsc"]),


### PR DESCRIPTION
This change maintains the existing behavior of the 'groovy' type, which
includes both .groovy and .gradle files.

PR #1470