### PR TITLE
ci: fix ci by removing fetch-depth 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
 
     - name: Install packages (Ubuntu)
       if: matrix.os == 'ubuntu-18.04'
@@ -185,8 +183,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:


### PR DESCRIPTION
It's not clear why removing this makes things work. I've submitted
PRs that passed CI with fetch-depth=1. Maybe it only fails when
PRs are submitted from external contributors?

Either way, for now, we remove this and absorb the extra cost in
order to get PRs passing CI again.

PR #1501