### PR TITLE
doc: fix typo "used" -> "use"

### DIFF
--- a/crates/core/app.rs
+++ b/crates/core/app.rs
@@ -1548,7 +1548,7 @@ When specifying multiple ignore files, earlier files have lower precedence
 than later files.
 
 If you are looking for a way to include or exclude files and directories
-directly on the command line, then used -g instead.
+directly on the command line, then use -g instead.
 "
     );
     let arg = RGArg::flag("ignore-file", "PATH")


### PR DESCRIPTION
PR #1936